### PR TITLE
fix(account_invoice_pricelist/models/account_move.py): Corriger _compute_price_unit pour gérer le multi-record et respecter la logique Odoo

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -188,11 +188,10 @@ class AccountMoveLine(models.Model):
         self.with_context(check_move_validity=False)[fname] = amount
         
     def _compute_price_unit(self):
-        price_unit = super(AccountMoveLine, self)._compute_price_unit()
-        if self.move_id.pricelist_id and self.move_id.is_invoice():
-            price_unit = self._get_price_with_pricelist()
-        return price_unit
-
+        for rec in self:
+            super(AccountMoveLine, rec)._compute_price_unit()
+            if rec.move_id.pricelist_id and rec.move_id.is_invoice():
+                rec.price_unit = rec._get_price_with_pricelist()
 
     
 class Pricelist(models.Model):


### PR DESCRIPTION
- Remplacement de l'appel direct à super() avec return par une boucle sur self.
- Utilisation de `super(..., rec)._compute_price_unit()` pour chaque enregistrement.
- Affectation directe de `rec.price_unit` au lieu de retourner une valeur.
- Préserve la logique native tout en appliquant le prix issu de la pricelist si nécessaire.
- Correction des problèmes potentiels lorsque self contient plusieurs lignes de facture.